### PR TITLE
Correct queries for language injections

### DIFF
--- a/languages/latex/injections.scm
+++ b/languages/latex/injections.scm
@@ -2,32 +2,32 @@
   (line_comment)
   (block_comment)
   (comment_environment)
-] @injection.content
-  (#set! injection.language "comment"))
+] @content
+  (#set! "language" "comment"))
 
 (pycode_environment
-  code: (source_code) @injection.content
-  (#set! injection.language "python"))
+  code: (source_code) @content
+  (#set! "language" "python"))
 
 (sagesilent_environment
-  code: (source_code) @injection.content
-  (#set! injection.language "python"))
+  code: (source_code) @content
+  (#set! "language" "python"))
 
 (sageblock_environment
-  code: (source_code) @injection.content
-  (#set! injection.language "python"))
+  code: (source_code) @content
+  (#set! "language" "python"))
 
 (minted_environment
   (begin
     language:
       (curly_group_text
-        (text) @injection.language))
-  (source_code) @injection.content)
+        (text) @language))
+  (source_code) @content)
 
 ((generic_environment
   (begin
     name:
       (curly_group_text
-        (text) @_env))) @injection.content
-  (#set! injection.language "c")
+        (text) @_env))) @content
+  (#set! "language" "c")
   (#any-of? @_env "asy" "asydef"))


### PR DESCRIPTION
Adjust the nvim-treesitter `injections.scm` file to the format specified in the [zed blog](https://zed.dev/blog/syntax-aware-editing#multi-language-documents).

Not tested systematically but definitely fixes the language injection for `sagesilent` environments to use python highlighting (before there was no highlighting):
![image](https://github.com/user-attachments/assets/172fb863-0733-4a5d-b54b-61779dc5a4c1)

