### PR TITLE
Add queries for outlining (part/chapter/section...)

### DIFF
--- a/languages/latex/outline.scm
+++ b/languages/latex/outline.scm
@@ -1,0 +1,79 @@
+; For each declaration, prioritize using the optional toc entry instead of the
+; curly group contents, which may contain non-text content
+
+; FUTURE: when possible consider processing things like \texorpdfstring{.}{.}
+; to only take pdfstring
+
+
+; CHAPTER DECLARATIONS
+
+(chapter
+  command: _ @context
+  !toc
+  text:
+    (curly_group
+      (_) @name)) @item
+
+(chapter
+  command: _ @context
+  toc:
+    (brack_group
+      (_) @name)) @item
+
+; PART DECLARATIONS
+
+(part
+  command: _ @context
+  toc:
+    (brack_group
+      (_) @name)) @item
+
+(part
+  command: _ @context
+  !toc
+  text:
+    (curly_group
+      (_) @name)) @item
+
+; SECTION DECLARATIONS
+
+(section
+  command: _ @context
+  toc:
+    (brack_group (_) @name)) @item
+
+(section
+  command: _ @context
+  !toc
+  text:
+    (curly_group
+      (_) @name )) @item
+
+; SUBSECTION DECLARATIONS
+
+(subsection
+  command: _ @context
+  toc:
+    (brack_group (_) @name)) @item
+
+(subsection
+  command: _ @context
+  !toc
+  text:
+    (curly_group
+      (_) @name )) @item
+
+; SUBSUBSECTION DECLARATIONS
+
+(subsubsection
+  command: _ @context
+  toc:
+    (brack_group (_) @name)) @item
+
+(subsubsection
+  command: _ @context
+  !toc
+  text:
+    (curly_group
+      (_) @name )) @item
+


### PR DESCRIPTION
# Outlining for LaTeX

Add new queries for outlining in LaTeX for:
- parts
- chapters
- sections
- subsections
- subsubsections


## Outcome:
The context at the cursor is indicated by the breadcrumbs above the buffer, or in the "outline" tab from where you can also navigate the file

![Screenshot from 2024-07-19 22-32-21](https://github.com/user-attachments/assets/bc2e37e6-cd79-475d-ba95-eca604451186)

## Subtlety

The curly bracket contents of the corresponding functions may have non-text content but sometimes the declarations include an optional argument in square brackets for the table of contents entry. When present it is safer to use that instead.

```latex
% typical part declaration
\part{Part Title} % use "Part Title" for outline name
% alternative with optional argument
\part[table of contents entry]{Part Title \\ with subtitle or maybe even more}
% this time use "table of contents entry" instead since it is provided
```

## Potential Future Improvement

I cannot find any directives that allow to modify the matched text [like #gsub! in neovim](https://neovim.io/doc/user/treesitter.html#treesitter-directives). But if ever this is possible, it would be good to trim out parts of the outline name which aren't very legible as plain text.

e.g. the ability to search and replace would allow:
```latex
\section{Exploring \texorpdfstring{$x^2$}{x squared)}
% use "Exploring x squared" as outline name
```