### PR TITLE
Add bibtex syntax highlighting

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -14,6 +14,10 @@ repository = "https://github.com/rzukic/zed-latex"
 name = "TexLab (Latex Language Server)"
 language = "LaTeX"
 
+[grammars.bibtex]
+repository = "https://github.com/latex-lsp/tree-sitter-bibtex"
+commit = "ccfd77db0ed799b6c22c214fe9d2937f47bc8b34"
+
 [grammars.latex]
 repository = "https://github.com/latex-lsp/tree-sitter-latex"
 commit = "841f89ffbba9650529a40fb867f3456bf92bf9b1"

--- a/languages/bibtex/config.toml
+++ b/languages/bibtex/config.toml
@@ -1,0 +1,10 @@
+name = "BibTeX"
+grammar = "bibtex"
+path_suffixes = ["bib", "bibtex", "biblatex"]
+line_comments = ["%"]
+autoclose_before = "}])"
+brackets = [
+    { start = "{", end = "}", close = true, newline = false },
+    { start = "[", end = "]", close = true, newline = false },
+    { start = "(", end = ")", close = true, newline = false },
+]

--- a/languages/bibtex/highlights.scm
+++ b/languages/bibtex/highlights.scm
@@ -1,0 +1,50 @@
+; CREDITS @pfoerster (adapted from https://github.com/latex-lsp/tree-sitter-bibtex)
+[
+  (string_type)
+  (preamble_type)
+  (entry_type)
+] @keyword
+
+[
+  (junk)
+  (comment)
+] @comment
+
+(comment) @spell
+
+[
+  "="
+  "#"
+] @operator
+
+(command) @function.builtin
+
+(number) @number
+
+(field
+  name: (identifier) @variable.member)
+
+(token
+  (identifier) @variable.parameter)
+
+[
+  (brace_word)
+  (quote_word)
+] @string
+
+[
+  (key_brace)
+  (key_paren)
+] @string.special.symbol
+
+(string
+  name: (identifier) @constant)
+
+[
+  "{"
+  "}"
+  "("
+  ")"
+] @punctuation.bracket
+
+"," @punctuation.delimiter


### PR DESCRIPTION
It makes sense to include bibtex highlighting for `.bib` files with a LaTeX plugin.

Here is a preview:
![image](https://github.com/user-attachments/assets/429d5570-7178-49fb-8d00-0a53b2ed3929)
