### PR TITLE
Expose LSP workspace settings to texlab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "latex"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "zed_extension_api",
 ]
@@ -312,9 +312,11 @@ dependencies = [
 
 [[package]]
 name = "zed_extension_api"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f4ae4e302a80591635ef9a236b35fde6fcc26cfd060e66fde4ba9f9fd394a1"
+checksum = "77ca8bcaea3feb2d2ce9dbeb061ee48365312a351faa7014c417b0365fe9e459"
 dependencies = [
+ "serde",
+ "serde_json",
  "wit-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 
 [lib]
@@ -8,4 +8,4 @@ path = "src/latex.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.5"
+zed_extension_api = "0.0.6"

--- a/src/latex.rs
+++ b/src/latex.rs
@@ -9,7 +9,7 @@ impl zed::Extension for LatexExtension {
 
     fn language_server_command(
         &mut self,
-        _config: zed::LanguageServerConfig,
+        _config: &zed::LanguageServerId,
         worktree: &zed::Worktree,
     ) -> zed::Result<zed::Command> {
         let path = worktree
@@ -21,6 +21,30 @@ impl zed::Extension for LatexExtension {
             args: vec![],
             env: Default::default(),
         })
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        _language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> zed::Result<Option<zed::serde_json::Value>> {
+        let settings = zed::settings::LspSettings::for_worktree("texlab", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings.clone())
+            .unwrap_or_default();
+        Ok(Some(settings))
+    }
+
+    fn language_server_initialization_options(
+            &mut self,
+            _language_server_id: &zed::LanguageServerId,
+            worktree: &zed::Worktree,
+        ) -> zed::Result<Option<zed::serde_json::Value>> {
+        let settings = zed::settings::LspSettings::for_worktree("texlab", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.initialization_options.clone())
+            .unwrap_or_default();
+        Ok(Some(settings))
     }
 }
 


### PR DESCRIPTION
Pass on the workspace settings relating to LSP on to texlab.

This allows immediate ability for users to configure texlab for their project. Here is an example of filtering the diagnostics:

https://github.com/user-attachments/assets/7f0c145d-15ac-4773-9791-7322f0ebf336

This opens up a bunch of possibilities for stuff, but the biggest one is probably setting up the build and preview through texlab.

At this point it would be good to have a wiki for this repo now with examples of such configs.
