### PR TITLE
Add `brackets.scm` for latex

### DIFF
--- a/languages/latex/brackets.scm
+++ b/languages/latex/brackets.scm
@@ -1,0 +1,68 @@
+; \left and \right delimiters
+(math_delimiter
+  left_command: _
+  left_delimiter: _ @open
+  right_command: _
+  right_delimiter: _ @close)
+
+; math
+(inline_formula
+  "$" @open
+  "$" @close)
+(inline_formula
+  "\\(" @open
+  "\\)" @close)
+(displayed_equation
+  "$$" @open
+  "$$" @close)
+(displayed_equation
+  "\\[" @open
+  "\\]" @close)
+
+; curly brackets
+(curly_group "{" @open "}" @close)
+(curly_group_text "{" @open "}" @close)
+(curly_group_text_list "{" @open "}" @close)
+(curly_group_path "{" @open "}" @close)
+(curly_group_path_list "{" @open "}" @close)
+(curly_group_command_name "{" @open "}" @close)
+(curly_group_key_value "{" @open "}" @close)
+(curly_group_glob_pattern "{" @open "}" @close)
+(curly_group_impl "{" @open "}" @close)
+(curly_group_author_list "{" @open "}" @close)
+
+; square brackets
+(brack_group "[" @open "]" @close)
+(brack_group_text "[" @open "]" @close)
+(brack_group_argc "[" @open "]" @close)
+(brack_group_key_value "[" @open "]" @close)
+
+; environments
+(generic_environment
+  begin: _ @open
+  end: _ @close)
+(comment_environment
+  begin: _ @open
+  end: _ @close)
+(verbatim_environment
+  begin: _ @open
+  end: _ @close)
+(listing_environment
+  begin: _ @open
+  end: _ @close)
+(minted_environment
+  begin: _ @open
+  end: _ @close)
+(pycode_environment
+  begin: _ @open
+  end: _ @close)
+(sagesilent_environment
+  begin: _ @open
+  end: _ @close)
+(sageblock_environment
+  begin: _ @open
+  end: _ @close)
+(math_environment
+  begin: _ @open
+  end: _ @close)
+


### PR DESCRIPTION
This includes curly braces, square brackets, mathematical delimiters with `\left` and `right`, and `\begin` and `\end` declarations for environments and other ways of entering mathmode (`$`, `$$`, `\[\]`, `\(\)`). Normal brackets and quotations are not strictly part of the syntax and the parser groups them into "words" so queries cannot be made for them anyway (unless used with `\left` and `\right`).

The end result is visual indicators for whatever currently "surrounds" the current position of the cursor.

https://github.com/user-attachments/assets/844aae54-0582-48f8-a12f-ae212372830b

**Limitation**: Other editors sometimes highlight `\left(` and `\right)` in
```latex
$\left(\frac{m}{n}\right)$
```
but `\left` and `(` are separate nodes in the syntax tree so can't seem to capture both at the same time, so only the brackets are highlighted.