### PR TITLE
Add injections for sage and lua commands

### DIFF
--- a/languages/latex/injections.scm
+++ b/languages/latex/injections.scm
@@ -31,3 +31,15 @@
         (text) @_env))) @content
   (#set! "language" "c")
   (#any-of? @_env "asy" "asydef"))
+
+(generic_command
+  command: (_) @_command
+  arg: (curly_group (_) @content)
+  (#set! "language" "python")
+  (#eq? @_command "\\sage"))
+
+(generic_command
+  command: (_) @_command
+  arg: (curly_group (_) @content)
+  (#set! "language" "lua")
+  (#any-of? @_command "\\directlua" "\\latelua"))


### PR DESCRIPTION
Add injections for other languages in `\directlua`, `\latelua` and `\sage`.
![image](https://github.com/user-attachments/assets/913558d0-5544-4a41-a087-2dd88f35d8bf)
The other place lua in lualatex can show up is in `luacode` environments, but adjustments to the latex parser need to be made before we can write a query for a language injection there.