### PR TITLE
Fix: switch latex grammar commit

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -20,4 +20,4 @@ commit = "ccfd77db0ed799b6c22c214fe9d2937f47bc8b34"
 
 [grammars.latex]
 repository = "https://github.com/latex-lsp/tree-sitter-latex"
-commit = "a834712c5e04029a451a262456bf6290b8ef6f37"
+commit = "a6c812704b3d3e1541b0853aa0d6d561301320e1"


### PR DESCRIPTION
Instead of using the latest tag for the latex grammar, use its parent commit which was the last commit to include the necessary `parser.c` file.

Relevant [PR](https://github.com/latex-lsp/tree-sitter-latex/pull/114)
in grammar repo.