### PR TITLE
Adjust auto-closing brackets

### DIFF
--- a/languages/latex/config.toml
+++ b/languages/latex/config.toml
@@ -2,14 +2,10 @@ name = "LaTeX"
 grammar = "latex"
 path_suffixes = ["tex", "latex", "sty", "cls"]
 line_comments = ["%"]
-autoclose_before = "\"}])'`"
+autoclose_before = "$}]'"
 brackets = [
     { start = "{", end = "}", close = true, newline = false },
     { start = "[", end = "]", close = true, newline = false },
-    { start = "(", end = ")", close = true, newline = false },
     { start = "$", end = "$", close = true, newline = false },
-    { start = "\"", end = "\"", close = true, newline = false },
-    { start = "'", end = "'", close = true, newline = false },
-    { start = "`", end = "`", close = true, newline = false },
-    { start = "``", end = "''", close = true, newline = false },
+    { start = "`", end = "'", close = true, newline = false },
 ]


### PR DESCRIPTION
There were a few conflicts in the auto-closing brackets. In particular, if two opening brackets end with the same character, then the second has no effect. Double/single quotes, and normal brackets "()" are not used in LaTeX syntax. Quotations in prose should be done like \`this' or \`\`that'' but only autoclosing \` is necessary as tapping it twice gives \`\`''. There are "paired brackets" with multiple characters that appear in LaTeX such as \left\{ and \right\} in mathmode, or \\[ \\] for a block equation. However `texlab` provides snippets for all of these, so that can be used instead and avoid the conflicts mentioned above.