### PR TITLE
Minor fix: incorrect asset link for x86 32bit

### DIFF
--- a/src/latex.rs
+++ b/src/latex.rs
@@ -115,7 +115,7 @@ fn acquire_latest_texlab(
     )?;
     let arch: &str = match arch {
         zed::Architecture::Aarch64 => "aarch64",
-        zed::Architecture::X86 => "x86",
+        zed::Architecture::X86 => "i686",
         zed::Architecture::X8664 => "x86_64",
     };
     let os: &str = match platform {


### PR DESCRIPTION
Whilst copying over the code from the Zig extension to create the download link for the Github release asset (for texlab), I forgot to check the name used for x86 (non-64) builds.

For example, it would create the wrong download link for https://github.com/latex-lsp/texlab/releases/download/v5.19.0/texlab-i686-windows.zip