### PR TITLE
Auto PDF preview config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "zed_extension_api"
-version = "0.0.6"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca8bcaea3feb2d2ce9dbeb061ee48365312a351faa7014c417b0365fe9e459"
+checksum = "594fd10dd0f2f853eb243e2425e7c95938cef49adb81d9602921d002c5e6d9d9"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,37 @@
 version = 3
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -15,10 +42,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "cc"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-targets",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -36,10 +160,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -48,7 +218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -59,9 +229,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "js-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "latex"
 version = "0.0.3"
 dependencies = [
+ "serde",
+ "serde_with",
  "zed_extension_api",
 ]
 
@@ -72,10 +253,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
+name = "libc"
+version = "0.2.159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -109,18 +323,18 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -139,6 +353,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +404,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +418,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -183,6 +470,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
 name = "wasm-encoder"
 version = "0.201.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,7 +540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fd83062c17b9f4985d438603cde0a5e8c5c8198201a6937f778b607924c7da2"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.2.6",
  "serde",
  "serde_derive",
  "serde_json",
@@ -214,9 +556,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84e5df6dba6c0d7fafc63a450f1738451ed7a0b52295d83e868218fa286bf708"
 dependencies = [
  "bitflags",
- "indexmap",
+ "indexmap 2.2.6",
  "semver",
 ]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -253,7 +668,7 @@ checksum = "d8a39a15d1ae2077688213611209849cad40e9e5cccf6e61951a425850677ff3"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.2.6",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -281,7 +696,7 @@ checksum = "421c0c848a0660a8c22e2fd217929a0191f14476b68962afd2af89fd22e39825"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.2.6",
  "log",
  "serde",
  "serde_derive",
@@ -300,7 +715,7 @@ checksum = "196d3ecfc4b759a8573bf86a9b3f8996b304b3732e4c7de81655f875f6efdca6"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.2.6",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,6 @@ path = "src/latex.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
+serde = "1.0.210"
+serde_with = "3.11.0"
 zed_extension_api = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ path = "src/latex.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/src/latex.rs
+++ b/src/latex.rs
@@ -31,6 +31,12 @@ impl zed::Extension for LatexExtension {
     ) -> zed::Result<zed::Command> {
         use zed::settings::BinarySettings;
 
+        // Check for the existence of a previewer
+        // (this has nothing to do with the language server but this
+        // is a convenient place to minimize the number of times this
+        // is done).
+        self.previewer = Preview::determine(worktree);
+
         let binary_settings = zed::settings::LspSettings::for_worktree("texlab", worktree)
             .ok()
             .and_then(|lsp_settings| lsp_settings.binary);
@@ -70,12 +76,6 @@ impl zed::Extension for LatexExtension {
         // Final priority for texlab: download from GitHub releases.
         let binary_path = acquire_latest_texlab(language_server_id)?;
         self.cached_texlab_path = Some(binary_path.clone());
-
-        // Check for the existence of a previewer
-        // (this has nothing to do with the language server but this
-        // is a convenient place to minimize the number of times this
-        // is done).
-        self.previewer = Preview::determine(worktree);
 
         Ok(zed::Command {
             command: binary_path,

--- a/src/preview_presets.rs
+++ b/src/preview_presets.rs
@@ -12,7 +12,7 @@ pub enum Preview {
 }
 
 impl Preview {
-    pub fn create_preset(self) -> TexlabForwardSearchSettings {
+    pub fn create_preset(&self) -> TexlabForwardSearchSettings {
         match self {
             Preview::Zathura => TexlabForwardSearchSettings {
                 executable: Some("zathura".to_string()),

--- a/src/preview_presets.rs
+++ b/src/preview_presets.rs
@@ -52,6 +52,10 @@ impl Preview {
                 executable: Some("okular".to_string()),
                 args: Some(vec!["--unique".to_string(), "file:%p#src:%l%f".to_string()]),
             },
+            Preview::QPDFView => TexlabForwardSearchSettings {
+                executable: Some("qpdfview".to_string()),
+                args: Some(vec!["--unique".to_string(), "%p#src:%f:%l:1".to_string()]),
+            },
             _ => TexlabForwardSearchSettings::default(),
         }
     }

--- a/src/preview_presets.rs
+++ b/src/preview_presets.rs
@@ -35,6 +35,19 @@ impl Preview {
                     "%f".to_string(),
                 ]),
             },
+            Preview::Sioyek => TexlabForwardSearchSettings {
+                executable: Some("sioyek".to_string()),
+                args: Some(vec![
+                    "--reuse-window".to_string(),
+                    "--inverse-search".to_string(),
+                    "zed %1:%2".to_string(),
+                    "--forward-search-file".to_string(),
+                    "%f".to_string(),
+                    "--forward-search-line".to_string(),
+                    "%l".to_string(),
+                    "%p".to_string(),
+                ]),
+            },
             _ => TexlabForwardSearchSettings::default(),
         }
     }

--- a/src/preview_presets.rs
+++ b/src/preview_presets.rs
@@ -48,6 +48,10 @@ impl Preview {
                     "%p".to_string(),
                 ]),
             },
+            Preview::Okular => TexlabForwardSearchSettings {
+                executable: Some("okular".to_string()),
+                args: Some(vec!["--unique".to_string(), "file:%p#src:%l%f".to_string()]),
+            },
             _ => TexlabForwardSearchSettings::default(),
         }
     }

--- a/src/preview_presets.rs
+++ b/src/preview_presets.rs
@@ -24,6 +24,17 @@ impl Preview {
                     "%p".to_string(),
                 ]),
             },
+            Preview::Skim => TexlabForwardSearchSettings {
+                executable: Some(
+                    "/Applications/Skim.app/Contents/SharedSupport/displayline".to_string(),
+                ),
+                args: Some(vec![
+                    "-r".to_string(),
+                    "%l".to_string(),
+                    "%p".to_string(),
+                    "%f".to_string(),
+                ]),
+            },
             _ => TexlabForwardSearchSettings::default(),
         }
     }

--- a/src/preview_presets.rs
+++ b/src/preview_presets.rs
@@ -1,0 +1,72 @@
+use crate::texlab_settings::*;
+use zed_extension_api as zed;
+
+#[allow(dead_code)]
+pub enum Preview {
+    Zathura,
+    Skim,
+    Sioyek,
+    QPDFView,
+    Okular,
+    SumatraPDF,
+}
+
+impl Preview {
+    pub fn create_preset(self) -> TexlabForwardSearchSettings {
+        match self {
+            Preview::Zathura => TexlabForwardSearchSettings {
+                executable: Some("zathura".to_string()),
+                args: Some(vec![
+                    "--synctex-forward".to_string(),
+                    "%l:1:%f".to_string(),
+                    "-x".to_string(),
+                    "zed %%{input}:%%{line}".to_string(),
+                    "%p".to_string(),
+                ]),
+            },
+            _ => TexlabForwardSearchSettings::default(),
+        }
+    }
+
+    pub fn determine(worktree: &zed::Worktree) -> Option<Preview> {
+        let (platform, _) = zed::current_platform();
+
+        if platform == zed::Os::Mac {
+            if worktree
+                .which("/Applications/Skim.app/Contents/SharedSupport/displayline")
+                .is_some()
+            {
+                return Some(Preview::Skim);
+            }
+        }
+
+        if worktree.which("zathura").is_some() {
+            return Some(Preview::Zathura);
+        }
+        if worktree.which("sioyek").is_some() {
+            return Some(Preview::Sioyek);
+        }
+        if worktree.which("sioyek").is_some() {
+            return Some(Preview::Sioyek);
+        }
+        if worktree.which("qpdfview").is_some() {
+            return Some(Preview::QPDFView);
+        }
+        if worktree.which("okular").is_some() {
+            return Some(Preview::Okular);
+        }
+
+        // Checking the existence of SumatraPDF will need
+        // the ability to find the user name
+        // if platform == zed::Os::Windows {
+        //     if worktree
+        //         .which("C:/Users/{User}/AppData/Local/SumatraPDF/SumatraPDF.exe")
+        //         .is_some()
+        //     {
+        //         return Some(Preview::SumatraPDF);
+        //     }
+        // }
+
+        None
+    }
+}

--- a/src/texlab_settings.rs
+++ b/src/texlab_settings.rs
@@ -1,0 +1,170 @@
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use std::vec::Vec;
+use zed_extension_api::serde_json::Value;
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceSettings {
+    pub texlab: Option<TexlabSettings>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TexlabSettings {
+    pub build: Option<TexlabBuildSettings>,
+    pub forward_search: Option<TexlabForwardSearchSettings>,
+    pub chktex: Option<Value>,
+    pub diagnostics_delay: Option<Value>,
+    pub symbols: Option<Value>,
+    pub formatter_line_length: Option<Value>,
+    pub bibtex_formatter: Option<Value>,
+    pub latex_formatter: Option<Value>,
+    pub latexindent: Option<Value>,
+    pub completion: Option<Value>,
+    pub inlay_hints: Option<Value>,
+    pub experimental: Option<Value>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TexlabBuildSettings {
+    pub executable: Option<String>,
+    pub args: Option<Vec<String>>,
+    pub forward_search_after: Option<bool>,
+    pub on_save: Option<bool>,
+    pub use_file_list: Option<Value>,
+    pub aux_directory: Option<Value>,
+    pub log_directory: Option<Value>,
+    pub pdf_directory: Option<Value>,
+}
+
+impl TexlabBuildSettings {
+    pub fn build_and_search_on() -> Self {
+        Self {
+            forward_search_after: Some(true),
+            on_save: Some(true),
+            ..Default::default()
+        }
+    }
+
+    /// When autoconfiguring preview settings, the `texlab.build.forwardSearchAfter`
+    /// and `texlab.build.onSave` fields should be set to `true` if they are not already set.
+    /// so that the user can see what is happening.
+    pub fn switch_on_onsave_fields_if_not_set(mut self) -> Self {
+        if self.forward_search_after.is_none() {
+            self.forward_search_after = Some(true);
+        }
+        if self.on_save.is_none() {
+            self.on_save = Some(true);
+        }
+        self
+    }
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TexlabForwardSearchSettings {
+    pub executable: Option<String>,
+    pub args: Option<Vec<String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zed_extension_api::serde_json::{self, json};
+
+    #[test]
+    fn test_deserialize_workspace_settings() {
+        let data = json!({
+            "texlab": {
+                "build": {
+                    "onSave": true,
+                    "forwardSearchAfter": true
+                },
+                "forwardSearch": {
+                    "executable": "zathura",
+                    "args": [
+                        "--synctex-forward",
+                        "%l:1:%f",
+                        "-x",
+                        "zed %%{input}:%%{line}",
+                        "%p"
+                    ]
+                },
+                "diagnostics": {
+                    "ignoredPatterns": []
+                }
+            }
+        });
+
+        let settings: WorkspaceSettings = serde_json::from_value(data).unwrap();
+
+        assert!(settings.texlab.is_some());
+        let texlab_settings = settings.texlab.unwrap();
+
+        assert!(texlab_settings.build.is_some());
+        let build_settings = texlab_settings.build.unwrap();
+        assert_eq!(build_settings.on_save, Some(true));
+        assert_eq!(build_settings.forward_search_after, Some(true));
+
+        assert!(texlab_settings.forward_search.is_some());
+        let forward_search_settings = texlab_settings.forward_search.unwrap();
+        assert_eq!(
+            forward_search_settings.executable,
+            Some("zathura".to_string())
+        );
+        assert_eq!(
+            forward_search_settings.args,
+            Some(vec![
+                "--synctex-forward".to_string(),
+                "%l:1:%f".to_string(),
+                "-x".to_string(),
+                "zed %%{input}:%%{line}".to_string(),
+                "%p".to_string()
+            ])
+        );
+
+        assert!(texlab_settings.diagnostics_delay.is_none());
+        assert!(texlab_settings.chktex.is_none());
+        assert!(texlab_settings.symbols.is_none());
+        assert!(texlab_settings.formatter_line_length.is_none());
+        assert!(texlab_settings.bibtex_formatter.is_none());
+        assert!(texlab_settings.latex_formatter.is_none());
+        assert!(texlab_settings.latexindent.is_none());
+        assert!(texlab_settings.completion.is_none());
+        assert!(texlab_settings.inlay_hints.is_none());
+        assert!(texlab_settings.experimental.is_none());
+    }
+    #[test]
+    fn test_serialize_forward_search_settings() {
+        let forward_search_settings = TexlabForwardSearchSettings {
+            executable: Some("zathura".to_string()),
+            args: Some(vec![
+                "--synctex-forward".to_string(),
+                "%l:1:%f".to_string(),
+                "-x".to_string(),
+                "zed %%{input}:%%{line}".to_string(),
+                "%p".to_string(),
+            ]),
+        };
+
+        let expected_json = json!({
+            "executable": "zathura",
+            "args": [
+                "--synctex-forward",
+                "%l:1:%f",
+                "-x",
+                "zed %%{input}:%%{line}",
+                "%p"
+            ]
+        });
+
+        let serialized = serde_json::to_value(&forward_search_settings).unwrap();
+        assert_eq!(serialized, expected_json);
+    }
+}


### PR DESCRIPTION
Listening to feedback from friends (and others), people do not want to set up a bespoke configuration for PDF preview and forwards/inverse search when starting out using this extension. The out-of-the-box experience should aim to be comparable to popular solutions such as Overleaf because that is the expectation these days. Then if the user requires something more bespoke, they can visit the wiki and create a custom configuration which should not be overriden by this extension.

This PR checks if any of the PDF viewers documented [here](https://github.com/latex-lsp/texlab/wiki/Previewing) are on PATH, or are in the standard location. If one is found, this fact is recorded. Then when workspace configurations are requested by `texlab`, if none of the user configurations define `texlab.forwardSearch` then this is automatically set with values corresponding to the detected PDF viewer to enable forwards/inverse search as much as possible.
> Some PDF viewers cannot have the inverse search set from the CLI so will need the user to adjust settings themselves. The user would need to visit the wiki on their own to find this out as there is no way to notify the user from the extension.

If `texlab.forwardSearch` is automatically configured, then the extension will also enable the options `texlab.build.afterSave` and `texlab.build.forwardSearchAfter` unless they are explicitly turned off by user settings. This is to match the default experience in other LaTeX IDEs.
However these two settings (`texlab.build.afterSave` and `texlab.build.forwardSearchAfter`) are not automatically enabled if `texlab.forwardSearch` is not auto-configured, notably when none of the PDF viewers are detected. This is because builds would be triggered without visual feedback (pdf preview), potentially leading to confusion and issues with stuff happening in the background that the user is not aware of.

**This isn't fully tested but still opening this PR now for any opinions or feedback on the topic as this change is opinionated.**