### PR TITLE
Add build tasks+runnable

### DIFF
--- a/languages/latex/runnables.scm
+++ b/languages/latex/runnables.scm
@@ -1,0 +1,2 @@
+(class_include
+ (#set! tag latex-build)) @run

--- a/languages/latex/tasks.json
+++ b/languages/latex/tasks.json
@@ -1,0 +1,30 @@
+[
+  {
+    "label": "latexmk",
+    "command": "latexmk",
+    "args": ["-synctex=1", "-pdf", "-recorder", "$ZED_FILENAME"],
+    "cwd": "$ZED_DIRNAME",
+    "tags": ["latex-build"]
+  },
+  {
+    "label": "latexmk (watch)",
+    "command": "latexmk",
+    "args": ["-pvc", "-synctex=1", "-pdf", "-recorder", "$ZED_FILENAME"],
+    "cwd": "$ZED_DIRNAME",
+    "tags": ["latex-build"]
+  },
+  {
+    "label": "pdflatex",
+    "command": "pdflatex",
+    "args": ["-synctex=1", "-recorder", "$ZED_FILENAME"],
+    "cwd": "$ZED_DIRNAME",
+    "tags": ["latex-build"]
+  },
+  {
+    "label": "lualatex",
+    "command": "lualatex",
+    "args": ["--synctex=1", "--recorder", "$ZED_FILENAME"],
+    "cwd": "$ZED_DIRNAME",
+    "tags": ["latex-build"]
+  }
+]


### PR DESCRIPTION
This PR add a play button next to `\documentclass` command (indicating that the current file must be the main file for a document). This button allows to run any task with the tag "latex-build", which this PR provides a couple of; but the user could add more.
![image](https://github.com/user-attachments/assets/d363b510-ce78-4eeb-8cb0-674f527ec3ae)
