### PR TITLE
Address #7: New user setting for extra directories in TEXINPUTS

### DIFF
--- a/src/latex.rs
+++ b/src/latex.rs
@@ -289,7 +289,7 @@ mod texlab_env {
             extra_tex_inputs: Some(texinputs),
         }) = init_opts.and_then(|json| from_value::<InitOpts>(json).ok())
         {
-            // directory separator (: on Mac/Linux, ; on Windows):
+            // Directory separator (: on Mac/Linux, ; on Windows):
             let sep = match zed::current_platform() {
                 (Os::Windows, _) => ";",
                 _ => ":",
@@ -297,16 +297,17 @@ mod texlab_env {
 
             let joined_extra_tex_inputs = texinputs.join(sep);
 
+            // To keep lifetime of env vars sufficiently long:
             let shell_env = worktree.shell_env();
-            // value of TEXINPUTS in environment var, if set and non-empty:
+            // Value of TEXINPUTS in environment var, if set and non-empty:
             let current_tex_inputs = shell_env
                 .iter()
-                .filter_map(|(var, val)| match (var.as_str(), val.as_str()) {
-                    ("TEXINPUTS", "") => None,
-                    ("TEXINPUTS", val) => Some(val),
+                .filter_map(|(var, val)| match var.as_str() {
+                    "TEXINPUTS" => Some(val),
                     _ => None,
                 })
-                .next();
+                .next()
+                .and_then(|val| if val.is_empty() { None } else { Some(val) });
 
             let tex_inputs = match current_tex_inputs {
                 // Starting . to check project first,


### PR DESCRIPTION
Following issue #7 and a recent [development](https://github.com/latex-lsp/texlab/pull/1252) in the `texlab` project, this PR repurposes the "initialization_options" Zed setting for texlab (which is not utilized) to house an extra option `extra_tex_inputs` to hold a list of absolute paths for the latex compiler to search.

This is achieved by making sure that `texlab` is invoked with the environment variable TEXINPUTS set accordingly, respecting any existing value it has in the shell environment.

This allows for settings such as this:
```jsonc
{
  "lsp": {
    "texlab": {
      "initialization_options": {
        // experimental: visit zed-latex wiki on github to check if setting location has moved
        "extra_tex_inputs": [
          "/extra/path/1/",
          "/extra/path/2/",
        ]
      }
    }
  }
}
```

Relative paths will also work, but they will be relative to the workspace root or the .texlabroot location. However, if a file is within the project, then it makes more sense to `\input` or `\import` it directly.

## Future:

Repurposing "initialization_options" is not ideal, potentially leads to confusion with how this information is communicated to `texlab`. However this is the only available option due to limitations in the extension API. The location of this setting is worth revisiting if one of these issues are addressed by the Zed team:
- https://github.com/zed-industries/zed/issues/19893
- https://github.com/zed-industries/zed/issues/17341