### PR TITLE
Improve paired delimiters which close themselves

### DIFF
--- a/languages/latex/config.toml
+++ b/languages/latex/config.toml
@@ -2,10 +2,28 @@ name = "LaTeX"
 grammar = "latex"
 path_suffixes = ["tex", "latex", "sty", "cls"]
 line_comments = ["%"]
-autoclose_before = "$}]'"
+autoclose_before = "$}]'\\"
 brackets = [
-    { start = "{", end = "}", close = true, newline = false, not_in = ["comment"] },
-    { start = "[", end = "]", close = true, newline = false, not_in = ["comment"] },
-    { start = "$", end = "$", close = true, newline = false, not_in = ["math", "comment"] },
-    { start = "`", end = "'", close = true, newline = false, not_in = ["math", "comment"] },
+    { start = "{", end = "}", close = true, newline = false, not_in = [
+        "comment",
+    ] },
+    { start = "\\[", end = "\\]", close = true, newline = true, not_in = [
+        "math",
+        "comment",
+    ] },
+    { start = "\\(", end = "\\)", close = true, newline = true, not_in = [
+        "math",
+        "comment",
+    ] },
+    { start = "[", end = "]", close = true, newline = false, not_in = [
+        "comment",
+    ] },
+    { start = "$", end = "$", close = true, newline = false, not_in = [
+        "math",
+        "comment",
+    ] },
+    { start = "`", end = "'", close = true, newline = false, not_in = [
+        "math",
+        "comment",
+    ] },
 ]

--- a/languages/latex/config.toml
+++ b/languages/latex/config.toml
@@ -4,8 +4,8 @@ path_suffixes = ["tex", "latex", "sty", "cls"]
 line_comments = ["%"]
 autoclose_before = "$}]'"
 brackets = [
-    { start = "{", end = "}", close = true, newline = false },
-    { start = "[", end = "]", close = true, newline = false },
-    { start = "$", end = "$", close = true, newline = false },
-    { start = "`", end = "'", close = true, newline = false },
+    { start = "{", end = "}", close = true, newline = false, not_in = ["comment"] },
+    { start = "[", end = "]", close = true, newline = false, not_in = ["comment"] },
+    { start = "$", end = "$", close = true, newline = false, not_in = ["math", "comment"] },
+    { start = "`", end = "'", close = true, newline = false, not_in = ["math", "comment"] },
 ]

--- a/languages/latex/overrides.scm
+++ b/languages/latex/overrides.scm
@@ -1,0 +1,15 @@
+;; Math
+[
+  (displayed_equation)
+  (inline_formula)
+] @math
+
+(math_environment
+  (_) @math)
+
+;; Comments
+[
+  (line_comment)
+  (block_comment)
+  (comment_environment)
+] @comment

--- a/languages/latex/overrides.scm
+++ b/languages/latex/overrides.scm
@@ -12,4 +12,4 @@
   (line_comment)
   (block_comment)
   (comment_environment)
-] @comment
+] @comment.inclusive


### PR DESCRIPTION
Zed improved their docs relating to paired brackets/delimiters: https://zed.dev/docs/extensions/languages#syntax-overrides

This PR takes this into account to make the bracket/delimiter closing more context aware.
There also doesn't seem to be any issues with having `\[` closed by `\]` anymore, so these are added as well as `\(`, `\)`, addressing #42.