### PR TITLE
Added a space after the "%" in line comment

### DIFF
--- a/languages/bibtex/config.toml
+++ b/languages/bibtex/config.toml
@@ -1,7 +1,7 @@
 name = "BibTeX"
 grammar = "bibtex"
 path_suffixes = ["bib", "bibtex", "biblatex"]
-line_comments = ["%"]
+line_comments = ["% "]
 autoclose_before = "}])"
 brackets = [
     { start = "{", end = "}", close = true, newline = false },

--- a/languages/latex/config.toml
+++ b/languages/latex/config.toml
@@ -1,7 +1,7 @@
 name = "LaTeX"
 grammar = "latex"
 path_suffixes = ["tex", "latex", "sty", "cls"]
-line_comments = ["%"]
+line_comments = ["% "]
 autoclose_before = "$}]'\\"
 brackets = [
     { start = "{", end = "}", close = true, newline = false, not_in = [


### PR DESCRIPTION
Currently, when I toggle a line into a comment or insert a new comment line, there is no space after the "%" symbol. However, adding a space after the comment symbol is considered good practice and aligns with the style used by [all built-in languages in Zed](https://github.com/search?q=repo%3Azed-industries%2Fzed+line_comments+language%3ATOML+path%3A%2F%5Ecrates%5C%2Flanguages%5C%2Fsrc%5C%2F%2F&type=code). Therefore, I suggest adding a space after "%" to maintain consistency with other languages.