### PR TITLE
Add rudimentary BibTeX outline

### DIFF
--- a/languages/bibtex/outline.scm
+++ b/languages/bibtex/outline.scm
@@ -1,0 +1,9 @@
+(entry
+  (key_brace) @context
+  (field
+    name: (identifier) @field_name
+    (#any-of? @field_name "title" "TITLE")
+    (value (_) @name)
+  )
+) @item
+


### PR DESCRIPTION
Closes #52 

Somewhat inspired by how the LaTeX outline keeps the \command as context, see breadcrumb bar at the top:
![image](https://github.com/user-attachments/assets/ac51cd35-9d2c-449a-903d-7e71c40d3428)

On one hand it would be nice to strip out the outer braces or quotes but I don't see any good way to do that with the current layout of the syntax tree and I don't want to get into modifying the grammar atm.