### PR TITLE
Fix #38: zed vs zeditor breaks inverse search

### DIFF
--- a/src/executable_name.rs
+++ b/src/executable_name.rs
@@ -6,6 +6,7 @@ pub enum Exe {
     Zeditor,
     Zedit,
     ZedEditor,
+    Flatpak,
 }
 
 impl Exe {
@@ -15,22 +16,50 @@ impl Exe {
             Exe::Zeditor => "zeditor",
             Exe::Zedit => "zedit",
             Exe::ZedEditor => "zed-editor",
+            Exe::Flatpak => "flatpak run dev.zed.Zed",
         }
     }
 
     pub fn determine(worktree: &zed::Worktree) -> Option<Self> {
+        if zed::Os::Linux == zed::current_platform().0 {
+            // The existence of the ZED_FLATPAK_LIB_PATH environment variable is
+            // a very strong indicator that Zed is running through flatpak.
+            // Even if zed is also installed the default way and is on PATH,
+            // the existence of this variable shows that, at the very least,
+            // the current process is a subprocess of the flatpak sandbox
+            // (and so the current zed window is from the flatpak install).
+            if worktree
+                .shell_env()
+                .iter()
+                .find(|&var| var.0 == "ZED_FLATPAK_LIB_PATH")
+                .is_some()
+            {
+                return Some(Exe::Flatpak);
+            }
+        }
+        // MINOR EDGE CASE WARNING
+        // Unlike the flatpak case, the rest of these tests could in principal be
+        // incorrect. For example, a user could have installed zed through a package
+        // manager and also the official way. In that case, the executable determined
+        // might not actually be the one that is running.
         if worktree.which("zed").is_some() {
+            // typical case
             return Some(Exe::Zed);
         }
-        if worktree.which("zeditor").is_some() {
-            return Some(Exe::Zeditor);
+
+        if zed::Os::Linux == zed::current_platform().0 {
+            // Known executables created by third-party package managers in linux
+            if worktree.which("zeditor").is_some() {
+                return Some(Exe::Zeditor);
+            }
+            if worktree.which("zedit").is_some() {
+                return Some(Exe::Zedit);
+            }
+            if worktree.which("zed-editor").is_some() {
+                return Some(Exe::ZedEditor);
+            }
         }
-        if worktree.which("zedit").is_some() {
-            return Some(Exe::Zedit);
-        }
-        if worktree.which("zed-editor").is_some() {
-            return Some(Exe::Zedit);
-        }
+
         None
     }
 }

--- a/src/executable_name.rs
+++ b/src/executable_name.rs
@@ -5,6 +5,7 @@ pub enum Exe {
     Zed,
     Zeditor,
     Zedit,
+    ZedEditor,
 }
 
 impl Exe {
@@ -13,6 +14,7 @@ impl Exe {
             Exe::Zed => "zed",
             Exe::Zeditor => "zeditor",
             Exe::Zedit => "zedit",
+            Exe::ZedEditor => "zed-editor",
         }
     }
 
@@ -24,6 +26,9 @@ impl Exe {
             return Some(Exe::Zeditor);
         }
         if worktree.which("zedit").is_some() {
+            return Some(Exe::Zedit);
+        }
+        if worktree.which("zed-editor").is_some() {
             return Some(Exe::Zedit);
         }
         None

--- a/src/executable_name.rs
+++ b/src/executable_name.rs
@@ -1,0 +1,37 @@
+use zed_extension_api as zed;
+
+#[derive(Copy, Clone)]
+pub enum Exe {
+    Zed,
+    Zeditor,
+    Zedit,
+}
+
+impl Exe {
+    pub fn to_str(&self) -> &'static str {
+        match self {
+            Exe::Zed => "zed",
+            Exe::Zeditor => "zeditor",
+            Exe::Zedit => "zedit",
+        }
+    }
+
+    pub fn determine(worktree: &zed::Worktree) -> Option<Self> {
+        if worktree.which("zed").is_some() {
+            return Some(Exe::Zed);
+        }
+        if worktree.which("zeditor").is_some() {
+            return Some(Exe::Zeditor);
+        }
+        if worktree.which("zedit").is_some() {
+            return Some(Exe::Zedit);
+        }
+        None
+    }
+}
+
+impl Default for Exe {
+    fn default() -> Self {
+        Exe::Zed
+    }
+}

--- a/src/latex.rs
+++ b/src/latex.rs
@@ -1,10 +1,10 @@
-mod executable_name;
 mod preview_presets;
 mod texlab_settings;
+mod zed_command;
 
-use executable_name::Exe;
 use preview_presets::*;
 use texlab_settings::{TexlabBuildSettings, TexlabSettings, WorkspaceSettings};
+use zed_command::CommandName;
 use zed_extension_api::{self as zed, serde_json};
 
 #[derive(Default)]
@@ -15,7 +15,7 @@ struct LatexExtension {
     /// Detected PDF previewer
     previewer: Option<Preview>,
     /// Executable to invoke the zed editor (None if not on PATH)
-    exe: Option<Exe>,
+    zed_command: Option<CommandName>,
 }
 
 impl zed::Extension for LatexExtension {
@@ -41,7 +41,7 @@ impl zed::Extension for LatexExtension {
         // is a convenient place to minimize the number of times this
         // is done).
         self.previewer = Preview::determine(worktree);
-        self.exe = Exe::determine(worktree);
+        self.zed_command = CommandName::determine(worktree);
 
         let lsp_settings =
             zed::settings::LspSettings::for_worktree("texlab", worktree).unwrap_or_default();
@@ -120,7 +120,7 @@ impl zed::Extension for LatexExtension {
                             texlab: Some(TexlabSettings {
                                 build: Some(TexlabBuildSettings::build_and_search_on()),
                                 forward_search: Some(
-                                    previewer.create_preset(self.exe.unwrap_or_default()),
+                                    previewer.create_preset(self.zed_command.unwrap_or_default()),
                                 ),
                                 ..Default::default()
                             }),
@@ -136,7 +136,7 @@ impl zed::Extension for LatexExtension {
                         serde_json::to_value(WorkspaceSettings {
                             texlab: Some(TexlabSettings {
                                 forward_search: Some(
-                                    previewer.create_preset(self.exe.unwrap_or_default()),
+                                    previewer.create_preset(self.zed_command.unwrap_or_default()),
                                 ),
                                 build: Some(
                                     texlab_settings_without_forward_search

--- a/src/preview_presets.rs
+++ b/src/preview_presets.rs
@@ -1,3 +1,4 @@
+use crate::executable_name::Exe;
 use crate::texlab_settings::*;
 use zed_extension_api as zed;
 
@@ -12,7 +13,7 @@ pub enum Preview {
 }
 
 impl Preview {
-    pub fn create_preset(&self) -> TexlabForwardSearchSettings {
+    pub fn create_preset(&self, exe: Exe) -> TexlabForwardSearchSettings {
         match self {
             Preview::Zathura => TexlabForwardSearchSettings {
                 executable: Some("zathura".to_string()),
@@ -20,7 +21,7 @@ impl Preview {
                     "--synctex-forward".to_string(),
                     "%l:1:%f".to_string(),
                     "-x".to_string(),
-                    "zed %%{input}:%%{line}".to_string(),
+                    format!("{} {}", exe.to_str(), "%%{input}:%%{line}"),
                     "%p".to_string(),
                 ]),
             },
@@ -40,7 +41,7 @@ impl Preview {
                 args: Some(vec![
                     "--reuse-window".to_string(),
                     "--inverse-search".to_string(),
-                    "zed \"%%1\":%%2".to_string(),
+                    format!("{} \"%%1\":%%2", exe.to_str()),
                     "--forward-search-file".to_string(),
                     "%f".to_string(),
                     "--forward-search-line".to_string(),

--- a/src/preview_presets.rs
+++ b/src/preview_presets.rs
@@ -1,5 +1,5 @@
-use crate::executable_name::Exe;
 use crate::texlab_settings::*;
+use crate::zed_command::CommandName;
 use zed_extension_api as zed;
 
 #[allow(dead_code)]
@@ -13,7 +13,7 @@ pub enum Preview {
 }
 
 impl Preview {
-    pub fn create_preset(&self, exe: Exe) -> TexlabForwardSearchSettings {
+    pub fn create_preset(&self, zed_command: CommandName) -> TexlabForwardSearchSettings {
         match self {
             Preview::Zathura => TexlabForwardSearchSettings {
                 executable: Some("zathura".to_string()),
@@ -21,7 +21,7 @@ impl Preview {
                     "--synctex-forward".to_string(),
                     "%l:1:%f".to_string(),
                     "-x".to_string(),
-                    format!("{} {}", exe.to_str(), "%%{input}:%%{line}"),
+                    format!("{} {}", zed_command.to_str(), "%%{input}:%%{line}"),
                     "%p".to_string(),
                 ]),
             },
@@ -41,7 +41,7 @@ impl Preview {
                 args: Some(vec![
                     "--reuse-window".to_string(),
                     "--inverse-search".to_string(),
-                    format!("{} \"%%1\":%%2", exe.to_str()),
+                    format!("{} \"%%1\":%%2", zed_command.to_str()),
                     "--forward-search-file".to_string(),
                     "%f".to_string(),
                     "--forward-search-line".to_string(),

--- a/src/zed_command.rs
+++ b/src/zed_command.rs
@@ -1,7 +1,7 @@
 use zed_extension_api as zed;
 
 #[derive(Copy, Clone)]
-pub enum Exe {
+pub enum CommandName {
     Zed,
     Zeditor,
     Zedit,
@@ -9,14 +9,14 @@ pub enum Exe {
     Flatpak,
 }
 
-impl Exe {
+impl CommandName {
     pub fn to_str(&self) -> &'static str {
         match self {
-            Exe::Zed => "zed",
-            Exe::Zeditor => "zeditor",
-            Exe::Zedit => "zedit",
-            Exe::ZedEditor => "zed-editor",
-            Exe::Flatpak => "flatpak run dev.zed.Zed",
+            CommandName::Zed => "zed",
+            CommandName::Zeditor => "zeditor",
+            CommandName::Zedit => "zedit",
+            CommandName::ZedEditor => "zed-editor",
+            CommandName::Flatpak => "flatpak run dev.zed.Zed",
         }
     }
 
@@ -34,7 +34,7 @@ impl Exe {
                 .find(|&var| var.0 == "ZED_FLATPAK_LIB_PATH")
                 .is_some()
             {
-                return Some(Exe::Flatpak);
+                return Some(CommandName::Flatpak);
             }
         }
         // MINOR EDGE CASE WARNING
@@ -44,19 +44,19 @@ impl Exe {
         // might not actually be the one that is running.
         if worktree.which("zed").is_some() {
             // typical case
-            return Some(Exe::Zed);
+            return Some(CommandName::Zed);
         }
 
         if zed::Os::Linux == zed::current_platform().0 {
             // Known executables created by third-party package managers in linux
             if worktree.which("zeditor").is_some() {
-                return Some(Exe::Zeditor);
+                return Some(CommandName::Zeditor);
             }
             if worktree.which("zedit").is_some() {
-                return Some(Exe::Zedit);
+                return Some(CommandName::Zedit);
             }
             if worktree.which("zed-editor").is_some() {
-                return Some(Exe::ZedEditor);
+                return Some(CommandName::ZedEditor);
             }
         }
 
@@ -64,8 +64,8 @@ impl Exe {
     }
 }
 
-impl Default for Exe {
+impl Default for CommandName {
     fn default() -> Self {
-        Exe::Zed
+        CommandName::Zed
     }
 }


### PR DESCRIPTION
Similarly to how the autoconfig detects the presence of different pdf viewers, this PR attempts to detect the command to run zed. This is so that it can be used in inverse-search commands (whenever specified, i.e. just zathura and sioyek).

This attempts to detect:
- zed executable
- executables created by third party package managers on linux:
  - zeditor executable
  - zed-editor executable
  - zedit exucutable
- whether zed is running through flatpak