### PR TITLE
Complete #57: Add autoconfig for evince PDF viewer

### DIFF
--- a/src/preview_presets.rs
+++ b/src/preview_presets.rs
@@ -10,6 +10,7 @@ pub enum Preview {
     QPDFView,
     Okular,
     SumatraPDF,
+    Evince,
 }
 
 impl Preview {
@@ -74,6 +75,17 @@ impl Preview {
                 executable: Some("qpdfview".to_string()),
                 args: Some(vec!["--unique".to_string(), "%p#src:%f:%l:1".to_string()]),
             },
+            Preview::Evince => TexlabForwardSearchSettings {
+                executable: Some("evince-synctex".to_string()),
+                args: Some(vec![
+                    "-f".to_string(),
+                    "%l".to_string(),
+                    "-t".to_string(),
+                    "%f".to_string(),
+                    "%p".to_string(),
+                    format!("{} %%f:%%l", zed_command.to_str())
+                ]),
+            },
             _ => TexlabForwardSearchSettings::default(),
         }
     }
@@ -90,6 +102,9 @@ impl Preview {
             }
         }
 
+        if worktree.which("evince").is_some() {
+            return Some(Preview::Evince);
+        }
         if worktree.which("zathura").is_some() {
             return Some(Preview::Zathura);
         }

--- a/src/preview_presets.rs
+++ b/src/preview_presets.rs
@@ -1,5 +1,3 @@
-use std::env;
-
 use crate::texlab_settings::*;
 use crate::zed_command::CommandName;
 use zed_extension_api as zed;


### PR DESCRIPTION
If `evince` is found on PATH, then download a python wrapper which enables a CLI to forwards/inverse search with synctex (in the same location as the downloaded `texlab` releases).

If so set up the `forwardSearch` setting for `texlab` so that this python wrapper is called appropriately to have forwards+inverse search working out of the box.

### Requirements:
`evince` being a GNOME app, the script assumes the presence of `python` and the `dbus` library, typically provided by a package called `python3-dbus` (which is the only library used that is not in the standard library). Both of these are present on all linux distributions checked which ship with GNOME, and likely always found given the usage of dbus and python in many GNOME applications. But of course this cannot be guaranteed for any custom linux install which happens to have the evince binary.

The "cost of failure" here is low as if any of the assumptions do not hold then the forwards search command executed by `texlab` immediately fails without performing any action, failing silently to the user but behaving no differently to if the forwards search was not automatically configured.