### PR TITLE
Extra highlighting

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -20,5 +20,5 @@ repository = "https://github.com/latex-lsp/tree-sitter-bibtex"
 commit = "ccfd77db0ed799b6c22c214fe9d2937f47bc8b34"
 
 [grammars.latex]
-repository = "https://github.com/latex-lsp/tree-sitter-latex"
-commit = "a6c812704b3d3e1541b0853aa0d6d561301320e1"
+repository = "https://github.com/497e0bdf29873/tree-sitter-latex"
+commit = "858af2c24547c8ab9386281ece6ead6936dbc8d1"

--- a/extension.toml
+++ b/extension.toml
@@ -20,5 +20,5 @@ repository = "https://github.com/latex-lsp/tree-sitter-bibtex"
 commit = "ccfd77db0ed799b6c22c214fe9d2937f47bc8b34"
 
 [grammars.latex]
-repository = "https://github.com/497e0bdf29873/tree-sitter-latex"
-commit = "858af2c24547c8ab9386281ece6ead6936dbc8d1"
+repository = "https://github.com/latex-lsp/tree-sitter-latex"
+commit = "f736d24d89acbd90092d92089e5171e6a449db40"

--- a/languages/latex/highlights.scm
+++ b/languages/latex/highlights.scm
@@ -279,6 +279,12 @@
     (_) @emphasis.strong))
   (#any-of? @_name "\\textbf" "\\mathbf"))
 
+((generic_command
+  command: (command_name) @_name @function.todo
+  arg: (curly_group
+    (_) @comment.todo.text))
+  (#match? @_name "^\\\\.?.?todo$"))
+
 ;; File inclusion commands
 (class_include
   command: _ @keyword.import

--- a/languages/latex/highlights.scm
+++ b/languages/latex/highlights.scm
@@ -80,7 +80,7 @@
 
 (theorem_definition
   command: _ @function.macro
-  name: (curly_group_text
+  name: (curly_group_text_list
     (_) @constant)
   title: (curly_group (_) @title)?
   counter: (brack_group_text (_) @constant)?)

--- a/languages/latex/highlights.scm
+++ b/languages/latex/highlights.scm
@@ -279,11 +279,12 @@
     (_) @emphasis.strong))
   (#any-of? @_name "\\textbf" "\\mathbf"))
 
-((generic_command
-  command: (command_name) @_name @function.todo
+(todo
+  command: _ @function.todo
+  options: (brack_group
+    (_) @comment.todo.options)?
   arg: (curly_group
-    (_) @comment.todo.text))
-  (#match? @_name "^\\\\.?.?todo$"))
+      (_) @comment.todo.text))
 
 ((generic_command
   command: (command_name) @_name @function.added

--- a/languages/latex/highlights.scm
+++ b/languages/latex/highlights.scm
@@ -297,6 +297,11 @@
     (_) @changes.deleted))
   (#eq? @_name "\\deleted"))
 
+(changes_replaced
+  command: _ @function.replaced
+  text_added: (curly_group (_) @changes.added)
+  text_deleted: (curly_group (_) @changes.deleted))
+
 ;; File incl
 
 ;; File inclusion commands

--- a/languages/latex/highlights.scm
+++ b/languages/latex/highlights.scm
@@ -285,6 +285,20 @@
     (_) @comment.todo.text))
   (#match? @_name "^\\\\.?.?todo$"))
 
+((generic_command
+  command: (command_name) @_name @function.added
+  arg: (curly_group
+    (_) @changes.added))
+  (#eq? @_name "\\added"))
+
+((generic_command
+  command: (command_name) @_name @function.deleted
+  arg: (curly_group
+    (_) @changes.deleted))
+  (#eq? @_name "\\deleted"))
+
+;; File incl
+
 ;; File inclusion commands
 (class_include
   command: _ @keyword.import

--- a/languages/latex/highlights.scm
+++ b/languages/latex/highlights.scm
@@ -93,59 +93,59 @@
 (label_definition
   command: _ @function.macro
   name: (curly_group_text
-    (_) @constant))
+    (_) @constant.label))
 
 (label_reference_range
   command: _ @function.macro
   from: (curly_group_text
     (_) @constant)
   to: (curly_group_text
-    (_) @constant))
+    (_) @constant.label))
 
 (label_reference
   command: _ @function.macro
   names: (curly_group_text_list
-    (_) @constant))
+    (_) @constant.label))
 
 (label_number
   command: _ @function.macro
   name: (curly_group_text
     (_) @constant)
-  number: (_) @constant)
+  number: (_) @constant.label)
 
 (citation
   command: _ @function.macro
-  keys: (curly_group_text_list) @constant)
+  keys: (curly_group_text_list) @constant.citation)
 
 (label_definition
   name: (curly_group_text
     (text
-      word: (operator "-") @constant)))
+      word: (operator "-") @constant.label)))
 
 (label_definition
   name: (curly_group_text
     (text
-      word: (subscript "_" @constant))))
+      word: (subscript "_" @constant.label))))
 
 (label_definition
   name: (curly_group_text
     (text
-      word: (superscript "^" @constant))))
+      word: (superscript "^" @constant.label))))
 
 (label_reference
   names: (curly_group_text_list
     (text
-      word: (operator "-") @constant)))
+      word: (operator "-") @constant.label)))
 
 (label_reference
   names: (curly_group_text_list
     (text
-      word: (subscript "_" @constant))))
+      word: (subscript "_" @constant.label))))
 
 (label_reference
   names: (curly_group_text_list
     (text
-      word: (superscript "^" @constant))))
+      word: (superscript "^" @constant.label))))
 
 ; Does not currently exist in the LaTeX grammar, maybe to come?:
 ;(hyperlink


### PR DESCRIPTION
This adds support for
* `\todo` and custom `\XXtodo` where `XX` are initialis of whom the todo corresponds to.
* `\added`, `\deleted`, `\replaced`.
It changes `constant` to `constant.label` or `constnat.citation` for labels and citations, to allow themes to configure specialised colours.

Corresponding modified themes are at https://github.com/497e0bdf29873/zed-themes.

Because the optional argument of `\todo`, and the two arguments of `\replaced` require changes in tree-sitter-latex, these changes currently refer to the fork https://github.com/497e0bdf29873/tree-sitter-latex. To be able to base that fork on the latest tree-sitter-latex, I also had to update `theorem_definition` to use `curly_group_text*_list*`, and to add an extra workaround commit, unlikely and in my own view undesired to be incorporate into tree-sitter-latex itself, that restores `src/parser.c` etc. generated by `npx tree-sitter generate`. These files used to be included in older versions of tree-sitter-latex, but are no longer included.

![image](https://github.com/user-attachments/assets/8bf6b7ea-caa9-4cbb-bcc2-34e28c04d3a2)
