### PR TITLE
Fix(#80): Add build command default, and refactor

### DIFF
--- a/src/texlab_workspace_config/types.rs
+++ b/src/texlab_workspace_config/types.rs
@@ -51,14 +51,6 @@ pub struct TexlabBuildSettings {
 }
 
 impl TexlabBuildSettings {
-    pub fn build_and_search_on() -> Self {
-        Self {
-            forward_search_after: Some(true),
-            on_save: Some(true),
-            ..Default::default()
-        }
-    }
-
     /// When autoconfiguring preview settings, the `texlab.build.forwardSearchAfter`
     /// and `texlab.build.onSave` fields should be set to `true` if they are not already set.
     /// so that the user can see what is happening.


### PR DESCRIPTION
To simplify code and avoid having to keep track of case when the user settings fail to deserialize, an error is just thrown. This isn't a terrible thing since this just tells the user loud and clear that they didn't set the lsp settings correctly.