### PR TITLE
Update highlights and add textobjects

### DIFF
--- a/languages/latex/highlights.scm
+++ b/languages/latex/highlights.scm
@@ -4,8 +4,6 @@
 (caption
   command: _ @function)
 
-; Turn spelling on for text
-;(text) @none
 
 ; \text, \intertext, \shortintertext, ...
 (text_mode
@@ -20,10 +18,9 @@
   key: (_) @variable.parameter
   value: (_))
 
-; Does not currently exist in the LaTeX grammar, maybe to come?:
-;(curly_group_spec
-;  (text) @variable.parameter)
-;
+(curly_group_spec
+  (text) @variable.parameter)
+
 
 (brack_group_argc) @attribute
 
@@ -36,8 +33,7 @@
 
 "\\item" @punctuation.list_marker
 
-; Does not currently exist in the LaTeX grammar, maybe to come?:
-;(delimiter) @punctuation.delimiter
+(delimiter) @punctuation.delimiter
 
 (math_delimiter
   left_command: _ @punctuation.bracket
@@ -147,17 +143,9 @@
     (text
       word: (superscript "^" @constant.label))))
 
-; Does not currently exist in the LaTeX grammar, maybe to come?:
-;(hyperlink
-  ;command: (_) @function
-  ;uri: (_) @link_uri)
-((generic_command
-  command: (command_name) @_name @function
-  .
-  arg:
-    (curly_group
-      (_) @link_uri))
-  (#any-of? @_name "\\url" "\\href"))
+(hyperlink
+  command: _ @function
+  uri: (_) @link_uri)
 
 (glossary_entry_definition
   command: _ @function.macro

--- a/languages/latex/textobjects.scm
+++ b/languages/latex/textobjects.scm
@@ -1,5 +1,79 @@
-(section
-  command: "\\section"
-  .
+; Class textobject
+
+(part
   text: (_)
-  (_)* @class.inner ) @class.outer
+  .
+  (_)* @class.inside ) @class.around
+
+(chapter
+  text: (_)
+  .
+  (_)* @class.inside ) @class.around
+
+(section
+  text: (_)
+  .
+  (_)* @class.inside ) @class.around
+
+(subsection
+  text: (_)
+  .
+  (_)* @class.inside ) @class.around
+
+(subsubsection
+  text: (_)
+  .
+  (_)* @class.inside ) @class.around
+
+; I don't think these are useful over { } vim motions
+; (paragraph
+;   text: (_)
+;   .
+;   (_)* @class.inside ) @class.around
+;
+; (subparagraph
+;   text: (_)
+;   .
+;   (_)* @class.inside ) @class.around
+
+
+; Function textobject
+
+(generic_environment
+  begin: (_)
+; (begin
+;     name: (curly_group_text
+;     text: (_) @_not_document)
+;     (#not-eq? @_not_document "document"))
+  .
+  (_)* @function.inside
+  .
+  end: (_)) @function.around
+
+(math_environment
+  begin: (_)
+  .
+  _* @function.inside
+  .
+  end: (_)) @function.around
+
+(displayed_equation
+  "$$"
+  .
+  _* @function.inside
+  .
+  "$$") @function.around
+
+(displayed_equation
+  "\\["
+  .
+  _* @function.inside
+  .
+  "\\]") @function.around
+
+; Comment textobject
+
+((line_comment)+ @comment.around)
+
+(block_comment
+  comment: _ @comment.inside) @comment.around


### PR DESCRIPTION
After the update in the version of the tree-sitter grammar used, some highlight queries needed updating.

Also textobjects have been added (with sensible inside/outside variants):
- "classes" matches parts/chapters/sections/...
- "functions" match environments and display math blocks
- "comments" ... are comments