### PR TITLE
Respect `$pdf_mode` in latexmkrc

### DIFF
--- a/languages/latex/tasks.json
+++ b/languages/latex/tasks.json
@@ -2,14 +2,14 @@
   {
     "label": "latexmk",
     "command": "latexmk",
-    "args": ["-synctex=1", "-pdf", "-recorder", "$ZED_FILENAME"],
+    "args": ["-synctex=1", "-e", "\"\\$pdf_mode = 1 unless \\$pdf_mode != 0;\"", "-recorder", "$ZED_FILENAME"],
     "cwd": "$ZED_DIRNAME",
     "tags": ["latex-build"]
   },
   {
     "label": "latexmk (watch)",
     "command": "latexmk",
-    "args": ["-pvc", "-synctex=1", "-pdf", "-recorder", "$ZED_FILENAME"],
+    "args": ["-pvc", "-synctex=1", "-e", "\"\\$pdf_mode = 1 unless \\$pdf_mode != 0;\"", "-recorder", "$ZED_FILENAME"],
     "cwd": "$ZED_DIRNAME",
     "tags": ["latex-build"]
   },


### PR DESCRIPTION
Force pdfLaTeX iff `$pdf_mode` is zero (no PDF produced by default).

Tested locally. Closes <https://github.com/rzukic/zed-latex/issues/108>.