### PR TITLE
Add .dtx and .ins to file name suffix list for LaTeX

### DIFF
--- a/languages/latex/config.toml
+++ b/languages/latex/config.toml
@@ -1,6 +1,6 @@
 name = "LaTeX"
 grammar = "latex"
-path_suffixes = ["tex", "latex", "sty", "cls"]
+path_suffixes = ["tex", "latex", "sty", "cls", "dtx", "ins"]
 line_comments = ["% "]
 autoclose_before = "$}]'\\"
 brackets = [


### PR DESCRIPTION
.dtx and .ins are used for package sources to be processed by [DocStrip](https://ctan.org/pkg/docstrip).