### PR TITLE
Reuse build args for latexmk

### DIFF
--- a/src/texlab_workspace_config/mod.rs
+++ b/src/texlab_workspace_config/mod.rs
@@ -91,20 +91,28 @@ fn add_build_default(input_settings: TexlabSettings) -> TexlabSettings {
                 }),
             ..
         } => input_settings,
-        _ => TexlabSettings {
-            build: Some(TexlabBuildSettings {
-                executable: Some("latexmk".to_string()),
-                args: Some(vec![
-                    "-e".into(),
-                    "$pdf_mode = 1 unless $pdf_mode != 0; if ($ARGV[-1] =~ /\\.log$/ or $ARGV[-1] =~ /latexmkrc$/) { exit 0; };".into(),
+        _ => {
+            let mut args = input_settings
+                .build
+                .as_ref()
+                .and_then(|b| b.args.clone())
+                .unwrap_or(vec![
                     "-interaction=nonstopmode".into(),
                     "-synctex=1".into(),
                     "%f".into(),
-                ]),
-                ..input_settings.build.unwrap_or_default()
-            }),
-            ..input_settings
-        },
+                ]);
+            args.insert(0, "-e".into());
+            args.insert(1, "$pdf_mode = 1 unless $pdf_mode != 0; if ($ARGV[-1] =~ /\\.log$/ or $ARGV[-1] =~ /latexmkrc$/) { exit 0; };".into());
+
+            TexlabSettings {
+                build: Some(TexlabBuildSettings {
+                    executable: Some("latexmk".to_string()),
+                    args: Some(args),
+                    ..input_settings.build.unwrap_or_default()
+                }),
+                ..input_settings
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Hi,

Thank you for this great extension, I love it!
I'm using custom build arguments for latexmk and noticed that this extension overrides them. This pull request makes sure that the build arguments in the `settings.json` file are used, and falls back to texlab's default arguments. 
I am not sure what the `pdf_mode` code those, but I think my changes do not break it. 

Please have a look and let me know what you think :)