### PR TITLE
MacOS: Fix bug where filenames with spaces are split

### DIFF
--- a/languages/latex/tasks.json
+++ b/languages/latex/tasks.json
@@ -2,28 +2,28 @@
   {
     "label": "latexmk",
     "command": "latexmk",
-    "args": ["-synctex=1", "-e", "\"\\$pdf_mode = 1 unless \\$pdf_mode != 0;\"", "-recorder", "$ZED_FILENAME"],
+    "args": ["-synctex=1", "-e", "\"\\$pdf_mode = 1 unless \\$pdf_mode != 0;\"", "-recorder", "\"$ZED_FILENAME\""],
     "cwd": "$ZED_DIRNAME",
     "tags": ["latex-build"]
   },
   {
     "label": "latexmk (watch)",
     "command": "latexmk",
-    "args": ["-pvc", "-synctex=1", "-e", "\"\\$pdf_mode = 1 unless \\$pdf_mode != 0;\"", "-recorder", "$ZED_FILENAME"],
+    "args": ["-pvc", "-synctex=1", "-e", "\"\\$pdf_mode = 1 unless \\$pdf_mode != 0;\"", "-recorder", "\"$ZED_FILENAME\""],
     "cwd": "$ZED_DIRNAME",
     "tags": ["latex-build"]
   },
   {
     "label": "pdflatex",
     "command": "pdflatex",
-    "args": ["-synctex=1", "-recorder", "$ZED_FILENAME"],
+    "args": ["-synctex=1", "-recorder", "\"$ZED_FILENAME\""],
     "cwd": "$ZED_DIRNAME",
     "tags": ["latex-build"]
   },
   {
     "label": "lualatex",
     "command": "lualatex",
-    "args": ["--synctex=1", "--recorder", "$ZED_FILENAME"],
+    "args": ["--synctex=1", "--recorder", "\"$ZED_FILENAME\""],
     "cwd": "$ZED_DIRNAME",
     "tags": ["latex-build"]
   }


### PR DESCRIPTION
Added quoting to $ZED_FILENAME in LaTeX tasks to prevent failures with spaces or apostrophes.