### PR TITLE
Add '-g' argument to Skim command which prevents changing focus

### DIFF
--- a/src/texlab_workspace_config/preview_presets.rs
+++ b/src/texlab_workspace_config/preview_presets.rs
@@ -64,6 +64,7 @@ impl Preview {
                     "/Applications/Skim.app/Contents/SharedSupport/displayline".to_string(),
                 ),
                 args: Some(vec![
+                    "-g".to_string(),
                     "-r".to_string(),
                     "%l".to_string(),
                     "%p".to_string(),


### PR DESCRIPTION
You mention this here as well and it's true. Focus should not go away from the editor on save. https://github.com/rzukic/zed-latex/wiki/Preview-%E2%80%90-MacOS