### PR TITLE
Fix inconsistent brace highlighting in \url and \href

### DIFF
--- a/languages/latex/highlights.scm
+++ b/languages/latex/highlights.scm
@@ -146,7 +146,8 @@
 
 (hyperlink
   command: _ @function
-  uri: (_) @link_uri)
+  uri: (curly_group_uri
+    (uri) @link_uri))
 
 (glossary_entry_definition
   command: _ @function.macro


### PR DESCRIPTION
## Problem

In a document containing e.g. `\url{https://langfuse.com/}`, the opening brace is highlighted in the link color while the closing brace is rendered as plain punctuation.

## Cause

The `hyperlink` rule in `highlights.scm` captured the whole `curly_group_uri` node as `@link_uri`:

```scheme
(hyperlink
  command: _ @function
  uri: (_) @link_uri)
```

In the grammar, `curly_group_uri` is `seq('{', field('uri', $.uri), '}')`, so the capture included both braces. The braces are also captured as `@punctuation.bracket` by the general bracket rule, and the overlapping captures were resolved inconsistently between the two braces.

## Fix

Capture only the inner `(uri)` node, so both braces are uniformly highlighted as `@punctuation.bracket` and only the URL text gets the link color:

```scheme
(hyperlink
  command: _ @function
  uri: (curly_group_uri
    (uri) @link_uri))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)